### PR TITLE
fix(container.py): heigh to height

### DIFF
--- a/book/src/ch02/src/container.py
+++ b/book/src/ch02/src/container.py
@@ -12,7 +12,7 @@ def mark_coordinate(grid, coord):
 class Boundaries:
     def __init__(self, width, height):
         self.width = width
-        self.height = heigh
+        self.height = height
 
     def __contains__(self, coord):
         x, y = coord


### PR DESCRIPTION
Fixing a typo in `container.py`. (`heigh` to `height`)